### PR TITLE
Use checkScreen() since checkFullPageScreen() has weird issues with h…

### DIFF
--- a/sharpeye.conf.js
+++ b/sharpeye.conf.js
@@ -61,6 +61,7 @@ exports.options = {
   // Specify the mismatch tolerance of the comparison.
   misMatchTolerance: 0,
   rawMisMatchPercentage: true,
+  pauseBeforeScreenshot: 0,
   numRetries: 0
 };
 

--- a/src/takeScreenshot.js
+++ b/src/takeScreenshot.js
@@ -52,7 +52,7 @@ const takeScreenshot = task => {
     if (task.viewports) {
       task.viewports.forEach(viewport => {
         alignHeight(viewport.width, viewport.height);
-        browser.pause(task.pause || 0);
+        browser.pause(task.pause || options.pauseBeforeScreenshot);
         assertDiff(browser.checkFullPageScreen(task.tag, screenshotOptions));
       });
 
@@ -65,15 +65,15 @@ const takeScreenshot = task => {
       // Full page with resize.
     } else if (task.fullPage) {
       // Let things settle a bit before calculating desired height.
-      browser.pause(1500);
+      browser.pause(task.pause || options.pauseBeforeScreenshot);
       alignHeight();
       // Let things settle after resize.
-      browser.pause(1500);
+      browser.pause(task.pause || options.pauseBeforeScreenshot);
       assertDiff(browser.checkScreen(task.tag, screenshotOptions));
 
       // Curren screen.
     } else {
-      browser.pause(task.pause || 0);
+      browser.pause(task.pause || options.pauseBeforeScreenshot);
       assertDiff(browser.checkScreen(task.tag, screenshotOptions));
     }
 

--- a/src/takeScreenshot.js
+++ b/src/takeScreenshot.js
@@ -65,10 +65,10 @@ const takeScreenshot = task => {
       // Full page with resize.
     } else if (task.fullPage) {
       // Let things settle a bit before calculating desired height.
-      browser.pause(task.pause || 0);
+      browser.pause(1500);
       alignHeight();
       // Let things settle after resize.
-      browser.pause(task.pause || 0);
+      browser.pause(1500);
       assertDiff(browser.checkScreen(task.tag, screenshotOptions));
 
       // Curren screen.

--- a/src/takeScreenshot.js
+++ b/src/takeScreenshot.js
@@ -69,7 +69,7 @@ const takeScreenshot = task => {
       alignHeight();
       // Let things settle after resize.
       browser.pause(task.pause || 0);
-      assertDiff(browser.checkFullPageScreen(task.tag, screenshotOptions));
+      assertDiff(browser.checkScreen(task.tag, screenshotOptions));
 
       // Curren screen.
     } else {


### PR DESCRIPTION
Use checkScreen() instead of checkFullPageScreen(), whichhas weird issues with height on chrome. Full page screenshots can only be taken in selenium docker